### PR TITLE
serve static files from public or s3

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -132,9 +132,8 @@ http {
     proxy_pass https://s3.amazonaws.com/neighbor-build-${environment}/sitemaps$request_uri;
   }
 
-  location ~ \.xml$|\.txt$ {
-    # bypass rendertron
-    try_files $uri =404;
+  location ~* ^/[^/]+\.(?:png|ico|txt|xml|json|svg|webmanifest)$ {
+    try_files /public/$uri @s3 =404;
   }
 
   # insert a slash between /storage-blog/ and the article names

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -117,7 +117,7 @@ http {
   }
   
   location ~ ^/assets/ {
-    try_files /public/$uri @s3;
+    try_files $uri @s3;
   }
 
   location @s3 {
@@ -133,7 +133,7 @@ http {
   }
 
   location ~* ^/[^/]+\.(?:png|ico|txt|xml|json|svg|webmanifest)$ {
-    try_files /public/$uri @s3 =404;
+    try_files $uri @s3;
   }
 
   # insert a slash between /storage-blog/ and the article names


### PR DESCRIPTION
Static assets for our frontend application aren't currently being served properly because all routes are being redirected to the index.html file. I attempted to add all of our static assets to the routes before the wildcard redirect so that they will be served as expected in https://github.com/neiybor/react-frontend/pull/4001 but this didn't actually fix the issue because of the custom things this buildpack is doing to transform that static.json file into an nginx.conf file.

This updates the nginx.conf template in this buildpack to include the routes as a location block instead of trying to pull it in from the frontend.

The regular expression used for matching on those files has been tested to ensure that it only matches the files we want. The slashes don't need to be escaped in nginx configuration, but the tester required that they be escaped: https://regex101.com/r/Hv8zOU/1