### PR TITLE
fix slash redirect

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -103,8 +103,8 @@ http {
     }
   <% end %>
 
-  location ~ ^(((?!storage-blog).)*)/$ { 
-    return 301 $scheme://$host$1;
+  location ~ ^/(((?!storage-blog).)*)/$ { 
+    return 301 $scheme://$http_host/$1;
   }
 
   # Redirect /links/x/state to /x/state


### PR DESCRIPTION
The slash redirect works great when redirecting from paths other than the root one (`/`), but from the root path it triggers an infinite redirect. This adds another slash at the front of the regular expression to require that the path have at least two slashes in it before triggering a redirect. This means that `/` won't match, but `/auth/` or `/hosts/` will, and I believe this is the behavior we want.

When I tested this with a url like `/hosts/` it was redirecting to `https://nbr.pizzahosts` so I also added a slash in the 301 location. And I used `$http_host` instead of `$host` so that when testing this locally with port 5001, it will include the port number in the URL as well.