### PR TITLE
add embeds url for registration iframe

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -103,6 +103,8 @@ http {
     }
   <% end %>
 
+  rewrite ^/embed/(.*)$ /$1.html last;
+
   location ~ ^/(((?!storage-blog).)*)/$ { 
     return 301 $scheme://$http_host/$1;
   }


### PR DESCRIPTION
This adds a new `/embeds` path for any iframe widgets we want to use in the future. This adds a rewrite so that any path like `/embeds/registration` will be rewritten to fetch the HTML file from the build directory with the same name as the second part of the path, so in this case `registration.html`. This would allow us to create other embeddable widgets in the future by following the same pattern of adding another webpack entrypoint like I did for the registration iframe.