### PR TITLE
pass through url parameters for ssr

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -231,7 +231,7 @@ http {
   # Redirect location DLPs to server-side rendered frontend
   # The /build directory is also needed because that's where the server-rendered JS comes from
   location ~ ^/((build|locations)/.*) {
-    proxy_pass <%= ssr_frontend_host %>/$1;
+    proxy_pass <%= ssr_frontend_host %>/$1$is_args$args;
   }
 
   location @proxy_fallback {


### PR DESCRIPTION
The back button isn't currently working for server-side rendered pages because it can't call the loader function. Remix handles the loader function being called client side by appending parameters to the URL that tell it which loader to call. This tells nginx to include the URL parameters in the request so that the data will be returned properly.

Here's the behavior before making this change:

https://user-images.githubusercontent.com/3421625/158677407-50208abd-583e-4a0e-b0af-e3da4bf14012.mp4

And here's what happens if you try again afterwards:

https://user-images.githubusercontent.com/3421625/158677460-0bfd9154-09db-4164-9e67-53cb82852cad.mp4