### PR TITLE
Add condition for fleet-parking search

### DIFF
--- a/scripts/config/lib/ngx_mruby/regions_path.rb
+++ b/scripts/config/lib/ngx_mruby/regions_path.rb
@@ -18,6 +18,8 @@ if types.length > 1
     # case climate-controlled storage, long term storage, long term parking
     "#{storage_type}#{suffix}-near-me/#{state.downcase}"
   end
+elsif state == 'search'
+  "#{types[0]}#{suffix}/search"
 else
   "#{types[0]}#{suffix}-near-me/#{state.downcase}"
 end


### PR DESCRIPTION
This should allow for the URL path `/fleet-parking/search` instead of redirecting that to `/fleet-parking-near-me/search`.