### PR TITLE
NED-13064 301 Redirect /fleet-parking directories to fleet parking landing page

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -252,9 +252,9 @@ http {
     return 301 https://$host/$1/$2/$3$is_args$args;
   }
 
-  # redirect fleet-storage-near-me DLPs to ssr fleet-parking-near-me DLPs
-  location ~ ^/fleet-storage-near-me/(.*) {
-    return 301 https://$host/fleet-parking-near-me/$1$is_args$args;
+  # Redirect fleet-storage-near-me and fleet-parking-near-me DLPs to SSR fleet parking landing page
+  location ~ ^/fleet-(storage|parking)-near-me/(.*) {
+    return 301 https://$host/commercial/fleet-parking/$1$is_args$args;
   }
 
   # The /build directory is also needed because that's where the server-rendered JS comes from
@@ -265,11 +265,6 @@ http {
 
   # Redirect location DLPs to server-side rendered frontend
   location ~ ^/((build)/.*) {
-    proxy_pass <%= ssr_frontend_host %>/$1$is_args$args;
-  }
-
-  # Redirect fleet search experience to ssr as well
-  location ~ ^/(fleet-parking\/search)$ {
     proxy_pass <%= ssr_frontend_host %>/$1$is_args$args;
   }
 

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -253,7 +253,7 @@ http {
   }
 
   # Redirect fleet-storage-near-me and fleet-parking-near-me DLPs to SSR fleet parking landing page
-  location ~ ^/fleet-(storage|parking)-near-me/(.*) {
+  location ~ ^/fleet-(storage|parking)-near-me(.*) {
     return 301 https://$host/commercial/fleet-parking/$1$is_args$args;
   }
 


### PR DESCRIPTION
Update nginx routing to direct traffic to /fleet-parking-near-me/* to the new fleet parking landing page. See https://github.com/neiybor/react-frontend/pull/5897 for demo and static routing.