### PR TITLE
ENG-451 Remove rule for /commercial

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -312,7 +312,7 @@ http {
   }
 
   # redirect all commercial, facility, location, and storage pages to ssr-frontend
-  location ~ ^/(commercial|facility|location|storage|business)\/(.*) {
+  location ~ ^/(facility|location|storage|business)\/(.*) {
     proxy_pass <%= ssr_frontend_host %>/$1/$2$is_args$args;
   }
 

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -311,7 +311,7 @@ http {
     return 301 https://www.neighbor.com/commercial/turo-fleet-car-parking;
   }
 
-  # redirect all commercial, facility, location, and storage pages to ssr-frontend
+  # redirect all business, facility, location, and storage pages to ssr-frontend
   location ~ ^/(facility|location|storage|business)\/(.*) {
     proxy_pass <%= ssr_frontend_host %>/$1/$2$is_args$args;
   }


### PR DESCRIPTION
All /commercial routes should no longer go to SSR frontend, so I removed that rule.