### PR TITLE
Allow digits for DLPs

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -393,12 +393,7 @@ http {
   }
 
   # redirect all near-me pages to SSR frontend
-  location ~ /((?!storage-units)[0-9A-z-]+-near-me(\/[A-z-]*)*$) {
-    proxy_pass <%= ssr_frontend_host %>/$1$is_args$args;
-  }
-
-  # this is an old commercial landing page that is no longer active. Redirect to ssr to use the 404 page
-  location ~ /(commercial-storage-near-me\/.*$) {
+  location ~ /((?!storage-units)[0-9A-z-]+-near-me\/.*$) {
     proxy_pass <%= ssr_frontend_host %>/$1$is_args$args;
   }
 


### PR DESCRIPTION
Our new listing detail panel on DLPs uses digits for the listingId in the URL. Therefore we need to allow those routes to be accessible.