### PR TITLE
ENG-6220 Remove redirects for new Strapi pages

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -299,11 +299,6 @@ http {
     return 301 https://$host/$1/$2/$3$is_args$args;
   }
 
-  # Redirect fleet-storage-near-me and fleet-parking-near-me DLPs to SSR fleet parking landing page
-  location ~ ^/fleet-(storage|parking)-near-me(.*) {
-    return 301 https://$host/business/fleet-parking$is_args$args;
-  }
-
   # Redirect deprecated DLP subtypes to their main type
 
   # Current deprecated subtypes are all truck storage subtypes, which should redirect to their parent type
@@ -348,10 +343,6 @@ http {
   # Redirect covered car to indoor, deprecating covered car
   location ~ ^/car-storage-near-me/covered(.*) {
     return 301 https://$host/car-storage-near-me/indoor/$1$is_args$args;
-  }
-
-  location ~ ^/trailer-storage-near-me(.*) {
-    return 301 https://$host/rv-storage-near-me$1$is_args$args;
   }
 
   # redirect warehouse storage dlps to the new commercial warehouse storage cms page

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -299,6 +299,11 @@ http {
     return 301 https://$host/$1/$2/$3$is_args$args;
   }
 
+  # Redirect fleet-storage-near-me and fleet-parking-near-me DLPs to SSR fleet parking landing page
+  location ~ ^/fleet-storage-near-me(.*) {
+    return 301 https://$host/business/fleet-parking$is_args$args;
+  }
+
   # Redirect deprecated DLP subtypes to their main type
 
   # Current deprecated subtypes are all truck storage subtypes, which should redirect to their parent type


### PR DESCRIPTION
The following pages needed to have an nginx redirect rule removed so that the new Strapi pages wouldn't return a 301 redirect:

- /fleet-parking-near-me
- /trailer-storage-near-me