### PR TITLE
Update buffer size for all of nginx

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -15,6 +15,7 @@ http {
   gzip_vary on;
   gzip_proxied any;
   map_hash_bucket_size 128;
+  proxy_buffer_size 16k;
 
   log_format custom_agent  'network.client.ip=$remote_addr network.client.ip_forward_chain=$http_x_forwarded_for timestamp=$time_iso8601 log_source="nginx" '
                            'http.method=$request_method http.url="$request_uri" http.status_code=$status network.bytes_written=$body_bytes_sent http.request_id=$http_x_request_id '


### PR DESCRIPTION
The default here is [4kb](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size)